### PR TITLE
Update hccapx_serializer.c

### DIFF
--- a/components/hccapx_serializer/hccapx_serializer.c
+++ b/components/hccapx_serializer/hccapx_serializer.c
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 #include <string.h>
+#include <netinet/in.h>
 #define LOG_LOCAL_LEVEL ESP_LOG_DEBUG
 #include "esp_log.h"
 #include "esp_err.h"


### PR DESCRIPTION
Include lib netinet/in.h to avoid error "implicit declaration of function 'ntohs'"